### PR TITLE
feat: Generalize Docker tags

### DIFF
--- a/.build/Build.Docker.cs
+++ b/.build/Build.Docker.cs
@@ -10,9 +10,9 @@ partial class Build : NukeBuild
 {
     private string DockerImage => $"ghcr.io/fetcharr/fetcharr";
 
-    private string[] DockerVersionTags => GitVersion.BranchName.Equals("develop", StringComparison.InvariantCultureIgnoreCase)
-        ? ["develop", $"develop-{GitVersion.MajorMinorPatch}.{GitVersion.PreReleaseNumber}"]
-        : ["latest", $"{GitVersion.Major}", $"{GitVersion.Major}.{GitVersion.Minor}", $"{GitVersion.MajorMinorPatch}"];
+    private string[] DockerVersionTags => GitVersion.BranchName.Equals("main", StringComparison.InvariantCultureIgnoreCase)
+        ? ["latest", $"{GitVersion.Major}", $"{GitVersion.Major}.{GitVersion.Minor}", $"{GitVersion.MajorMinorPatch}"]
+        : ["develop", $"develop-{GitVersion.MajorMinorPatch}.{GitVersion.PreReleaseNumber}"];
 
     private string[] DockerImageTags => DockerVersionTags.Select(version => $"{DockerImage}:{version}").ToArray();
 

--- a/.build/Build.Docker.cs
+++ b/.build/Build.Docker.cs
@@ -10,9 +10,11 @@ partial class Build : NukeBuild
 {
     private string DockerImage => $"ghcr.io/fetcharr/fetcharr";
 
-    private string DockerTag => GitVersion.SemVer;
+    private string[] DockerVersionTags => GitVersion.BranchName.Equals("develop", StringComparison.InvariantCultureIgnoreCase)
+        ? ["develop", $"develop-{GitVersion.MajorMinorPatch}.{GitVersion.PreReleaseNumber}"]
+        : ["latest", $"{GitVersion.Major}", $"{GitVersion.Major}.{GitVersion.Minor}", $"{GitVersion.MajorMinorPatch}"];
 
-    private string DockerImageTag => $"{DockerImage}:{DockerTag}";
+    private string[] DockerImageTags => DockerVersionTags.Select(version => $"{DockerImage}:{version}").ToArray();
 
     private string[] DockerImagePlatforms => ["linux/amd64", "linux/arm", "linux/arm64"];
 
@@ -24,7 +26,7 @@ partial class Build : NukeBuild
             DockerBuildxBuild(x => x
                 .SetPath(".")
                 .SetFile("Dockerfile")
-                .SetTag(this.DockerImageTag)
+                .SetTag(this.DockerImageTags)
                 .SetPlatform(string.Join(",", this.DockerImagePlatforms))
                 .SetPush(true)
                 .AddCacheFrom("type=gha")

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -84,7 +84,6 @@
               "Clean",
               "Compile",
               "Format",
-              "PushImage",
               "Release",
               "Restore",
               "Test"
@@ -101,7 +100,6 @@
               "Clean",
               "Compile",
               "Format",
-              "PushImage",
               "Release",
               "Restore",
               "Test"


### PR DESCRIPTION
Instead of using the `SemVer` variable directly, use more commonly-used formatting for Docker tags.

Before:
- **Development**: `0.1.0-alpha.01`
- **Release**: `0.1.0`

After:
- **Development**: `develop`, `develop-latest`
- **Release**: `0.1.0`, `0.1`, `0`, `latest`