### PR TITLE
feat: Add support for syncing watchlist of friends

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -169,6 +169,11 @@
         "api_token": {
           "type": "string",
           "description": "API token for authenticating with Plex.\nSee more here: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/"
+        },
+        "sync_friends_watchlist": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to include friends' watchlists when syncing."
         }
       }
     },

--- a/docs/docs/configuration/basic-setup.mdx
+++ b/docs/docs/configuration/basic-setup.mdx
@@ -39,6 +39,7 @@ Plex tokens are not permanent and will expire after some time. Continuously upda
 ```yaml
 plex:
   api_token: PLEX_TOKEN
+  sync_friends_watchlist: false
 ```
 
 To setup your Plex account in Fetcharr, you need to get your Plex token. While we could outline the steps for getting yours here, it would be better to refer til Plex' official documentation.
@@ -50,6 +51,13 @@ You can read their page on [getting your Plex token here](https://support.plex.t
 **You should not share your Plex token with anyone.** It will allow anyone to impersonate you on Plex.
 
 :::
+
+### `sync_friends_watchlist`
+**Optional.** Default: `false`
+
+Defines whether Fetcharr should also sync the watchlist of friends on Plex. This is useful when you have multiple users, who all have separate accounts instead of managed users, but you still want to fetch their watchlist.
+
+For this to work, your friends may need to set their watchlist visibility in Plex to be either `Friends Only` or `Friends of Friends`. [You can find the setting here](https://app.plex.tv/desktop/#!/settings/account) under `Setting > Account Visibility & Account Sharing > My Watchlist`.
 
 ## Service
 
@@ -116,7 +124,7 @@ Whether the instance should be enabled. This can be useful for playing around wi
 
 Which filters to apply to the instance. They can help limit what content will be sent to the instance, such as limiting an instance to be anime-only, kids-only, etc.
 
-For more information about filters, click here.
+For more information about filters, [click here](./filters.mdx).
 
 ### `root_folder`
 **Optional.** Default: `null`

--- a/fetcharr.example.yaml
+++ b/fetcharr.example.yaml
@@ -9,6 +9,10 @@ plex:
   ## If you need help finding yours, see here: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
   api_token: PLEX_TOKEN
 
+  ## Whether to include friends' watchlists when syncing.
+  ## Default: false
+  sync_friends_watchlist: false
+
 ## List of all Sonarr instances available
 sonarr:
   default:

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,7 +16,9 @@
   <ItemGroup>
     <PackageVersion Include="Flurl.Http" Version="4.0.2" />
     <PackageVersion Include="GitVersion.MsBuild" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7"/>
+    <PackageVersion Include="GraphQL.Client" Version="6.1.0" />
+    <PackageVersion Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />

--- a/src/Models/src/Configuration/Plex/FetcharrPlexConfiguration.cs
+++ b/src/Models/src/Configuration/Plex/FetcharrPlexConfiguration.cs
@@ -15,5 +15,12 @@ namespace Fetcharr.Models.Configuration.Plex
         [Required]
         [YamlMember(Alias = "api_token")]
         public string ApiToken { get; set; } = string.Empty;
+
+        /// <summary>
+        ///   Gets or sets whether to include friends' watchlists in the sync.
+        /// </summary>
+        [Required]
+        [YamlMember(Alias = "sync_friends_watchlist")]
+        public bool IncludeFriendsWatchlist { get; set; } = false;
     }
 }

--- a/src/Provider.Plex/src/Clients/PlexGraphQLClient.cs
+++ b/src/Provider.Plex/src/Clients/PlexGraphQLClient.cs
@@ -1,0 +1,131 @@
+using Fetcharr.Cache.Core;
+using Fetcharr.Models.Configuration;
+using Fetcharr.Provider.Plex.Models;
+using Fetcharr.Shared.GraphQL;
+
+using GraphQL;
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.SystemTextJson;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Fetcharr.Provider.Plex.Clients
+{
+    /// <summary>
+    ///   Client for interacting with Plex' GraphQL API.
+    /// </summary>
+    public class PlexGraphQLClient(
+        IOptions<FetcharrConfiguration> configuration,
+        [FromKeyedServices("plex-graphql")] ICachingProvider cachingProvider)
+    {
+        /// <summary>
+        ///   Gets the GraphQL endpoint for Plex.
+        /// </summary>
+        public const string GraphQLEndpoint = "https://community.plex.tv/api";
+
+        private readonly GraphQLHttpClient _client =
+            new GraphQLHttpClient(PlexGraphQLClient.GraphQLEndpoint, new SystemTextJsonSerializer())
+                .WithAutomaticPersistedQueries(_ => true)
+                .WithHeader("X-Plex-Token", configuration.Value.Plex.ApiToken)
+                .WithHeader("X-Plex-Client-Identifier", "fetcharr");
+
+        /// <summary>
+        ///   Gets the watchlist of a Plex account, who's a friend of the current plex account.
+        /// </summary>
+        public async Task<IEnumerable<WatchlistMetadataItem>> GetFriendWatchlistAsync(
+            string userId,
+            int count = 100,
+            string? cursor = null)
+        {
+            string cacheKey = $"friend-watchlist-{userId}";
+
+            CacheValue<IEnumerable<WatchlistMetadataItem>> cachedResponse = await cachingProvider
+                .GetAsync<IEnumerable<WatchlistMetadataItem>>(cacheKey);
+
+            if(cachedResponse.HasValue)
+            {
+                return cachedResponse.Value;
+            }
+
+            GraphQLRequest request = new()
+            {
+                Query = """
+                query GetFriendWatchlist($uuid: ID = "", $first: PaginationInt!, $after: String) {
+                    user(id: $uuid) {
+                        watchlist(first: $first, after: $after) {
+                            nodes {
+                                ... on MetadataItem {
+                                    title
+                                    ratingKey: id
+                                    year
+                                    type
+                                }
+                            }
+                            pageInfo {
+                                hasNextPage
+                                endCursor
+                            }
+                        }
+                    }
+                }
+                """,
+                OperationName = "GetFriendWatchlist",
+                Variables = new
+                {
+                    uuid = userId,
+                    first = count,
+                    after = cursor ?? string.Empty
+                }
+            };
+
+            GraphQLResponse<PlexUserWatchlistResponseType> response = await this._client
+                .SendQueryAsync<PlexUserWatchlistResponseType>(request);
+
+            response.ThrowIfErrors(message: "Failed to fetch friend's watchlist from Plex");
+
+            IEnumerable<WatchlistMetadataItem> watchlistItems = response.Data.User.Watchlist.Nodes;
+
+            await cachingProvider.SetAsync(cacheKey, watchlistItems, expiration: TimeSpan.FromHours(4));
+            return watchlistItems;
+        }
+
+        /// <summary>
+        ///   Gets all the friends of the current Plex account and returns them.
+        /// </summary>
+        public async Task<IEnumerable<PlexFriendUser>> GetAllFriendsAsync()
+        {
+            CacheValue<IEnumerable<PlexFriendUser>> cachedResponse = await cachingProvider
+                .GetAsync<IEnumerable<PlexFriendUser>>("friends-list");
+
+            if(cachedResponse.HasValue)
+            {
+                return cachedResponse.Value;
+            }
+
+            GraphQLRequest request = new()
+            {
+                Query = """
+                query {
+                    allFriendsV2 {
+                        user {
+                            id
+                            username
+                        }
+                    }
+                }
+                """
+            };
+
+            GraphQLResponse<PlexFriendListResponseType> response = await this._client
+                .SendQueryAsync<PlexFriendListResponseType>(request);
+
+            response.ThrowIfErrors(message: "Failed to fetch friends list from Plex");
+
+            IEnumerable<PlexFriendUser> friends = response.Data.Friends.Select(v => v.User);
+
+            await cachingProvider.SetAsync("friends-list", friends, expiration: TimeSpan.FromHours(4));
+            return friends;
+        }
+    }
+}

--- a/src/Provider.Plex/src/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Provider.Plex/src/Extensions/IServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Fetcharr.Provider.Plex.Clients;
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Fetcharr.Provider.Plex.Extensions
@@ -12,6 +14,9 @@ namespace Fetcharr.Provider.Plex.Extensions
             services.AddSingleton<PlexClient>();
             services.AddSingleton<PlexMetadataClient>();
             services.AddSingleton<PlexWatchlistClient>();
+            services.AddSingleton<PlexFriendsWatchlistClient>();
+
+            services.AddSingleton<PlexGraphQLClient>();
 
             return services;
         }

--- a/src/Provider.Plex/src/Fetcharr.Provider.Plex.csproj
+++ b/src/Provider.Plex/src/Fetcharr.Provider.Plex.csproj
@@ -14,4 +14,9 @@
     <ProjectReference Include="..\..\Models\src\Fetcharr.Models.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="GraphQL.Client" />
+    <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" />
+  </ItemGroup>
+
 </Project>

--- a/src/Provider.Plex/src/Models/Friends/PlexFriendListResponseType.cs
+++ b/src/Provider.Plex/src/Models/Friends/PlexFriendListResponseType.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Fetcharr.Provider.Plex.Models
+{
+    public class PlexFriendListResponseType
+    {
+        [JsonPropertyName("allFriendsV2")]
+        public List<PlexFriendUserContainer> Friends { get; set; } = [];
+    }
+}

--- a/src/Provider.Plex/src/Models/Friends/PlexFriendUser.cs
+++ b/src/Provider.Plex/src/Models/Friends/PlexFriendUser.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Fetcharr.Provider.Plex.Models
+{
+    /// <summary>
+    ///   Representation of a friend user account.
+    /// </summary>
+    public class PlexFriendUser
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("username")]
+        public string Username { get; set; } = string.Empty;
+    }
+}

--- a/src/Provider.Plex/src/Models/Friends/PlexFriendUserContainer.cs
+++ b/src/Provider.Plex/src/Models/Friends/PlexFriendUserContainer.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Fetcharr.Provider.Plex.Models
+{
+    /// <summary>
+    ///   Representation of a friend user account container.
+    /// </summary>
+    public class PlexFriendUserContainer
+    {
+        [JsonPropertyName("user")]
+        public PlexFriendUser User { get; set; } = new();
+    }
+}

--- a/src/Provider.Plex/src/Models/Friends/PlexUserWatchlistResponseType.cs
+++ b/src/Provider.Plex/src/Models/Friends/PlexUserWatchlistResponseType.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Fetcharr.Provider.Plex.Models
+{
+    public class PlexUserWatchlistResponseType
+    {
+        [JsonPropertyName("user")]
+        public PlexWatchlistResponseType User { get; set; } = new();
+    }
+
+    public class PlexWatchlistResponseType
+    {
+        [JsonPropertyName("watchlist")]
+        public PaginatedResult<WatchlistMetadataItem> Watchlist { get; set; } = new();
+    }
+}

--- a/src/Provider.Plex/src/Models/GraphQL/PaginatedResult.cs
+++ b/src/Provider.Plex/src/Models/GraphQL/PaginatedResult.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Fetcharr.Provider.Plex.Models
+{
+    public class PaginatedResult<T>
+    {
+        [JsonPropertyName("nodes")]
+        public List<T> Nodes { get; set; } = [];
+    }
+}

--- a/src/Provider.Plex/src/PlexClient.cs
+++ b/src/Provider.Plex/src/PlexClient.cs
@@ -14,7 +14,8 @@ namespace Fetcharr.Provider.Plex
     public class PlexClient(
         IOptions<FetcharrConfiguration> configuration,
         PlexMetadataClient metadataClient,
-        PlexWatchlistClient watchlistClient)
+        PlexWatchlistClient watchlistClient,
+        PlexFriendsWatchlistClient plexFriendsWatchlistClient)
         : ExternalProvider
     {
         private readonly FlurlClient _client =
@@ -34,6 +35,11 @@ namespace Fetcharr.Provider.Plex
         ///   Gets the underlying client for interacting with Plex watchlists.
         /// </summary>
         public readonly PlexWatchlistClient Watchlist = watchlistClient;
+
+        /// <summary>
+        ///   Gets the underlying client for interacting with Plex watchlists for friends.
+        /// </summary>
+        public readonly PlexFriendsWatchlistClient FriendsWatchlistClient = plexFriendsWatchlistClient;
 
         /// <inheritdoc />
         public override async Task<bool> PingAsync(CancellationToken cancellationToken)

--- a/src/Provider.Plex/src/PlexFriendsWatchlistClient.cs
+++ b/src/Provider.Plex/src/PlexFriendsWatchlistClient.cs
@@ -1,0 +1,32 @@
+using Fetcharr.Provider.Plex.Clients;
+using Fetcharr.Provider.Plex.Models;
+
+namespace Fetcharr.Provider.Plex
+{
+    /// <summary>
+    ///   Client for fetching friends' watchlists from Plex.
+    /// </summary>
+    public class PlexFriendsWatchlistClient(
+        PlexGraphQLClient plexGraphQLClient)
+    {
+        /// <summary>
+        ///   Fetch the watchlists for all the friends the current Plex account and return them.
+        /// </summary>
+        /// <param name="count">Maximum amount of items to fetch per watchlist.</param>
+        public async Task<IEnumerable<WatchlistMetadataItem>> FetchAllWatchlistsAsync(int count = 10)
+        {
+            List<WatchlistMetadataItem> joinedWatchlist = [];
+            IEnumerable<PlexFriendUser> friends = await plexGraphQLClient.GetAllFriendsAsync();
+
+            foreach(PlexFriendUser friend in friends)
+            {
+                IEnumerable<WatchlistMetadataItem> friendWatchlist = await plexGraphQLClient
+                    .GetFriendWatchlistAsync(friend.Id, count);
+
+                joinedWatchlist.AddRange(friendWatchlist);
+            }
+
+            return joinedWatchlist;
+        }
+    }
+}

--- a/src/Shared/src/Fetcharr.Shared.csproj
+++ b/src/Shared/src/Fetcharr.Shared.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GraphQL.Client" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 

--- a/src/Shared/src/GraphQL/GraphQLHttpClientExtensions.cs
+++ b/src/Shared/src/GraphQL/GraphQLHttpClientExtensions.cs
@@ -1,0 +1,34 @@
+using GraphQL;
+using GraphQL.Client.Http;
+
+namespace Fetcharr.Shared.GraphQL
+{
+    public static class GraphQLHttpClientExtensions
+    {
+        /// <summary>
+        ///   Appends a default HTTP header to send along with all GraphQL operations.
+        /// </summary>
+        /// <param name="client"><see cref="GraphQLHttpClient"/>-instance to add the header onto.</param>
+        /// <returns><paramref name="client"/> to allow for chaining calls.</returns>
+        public static GraphQLHttpClient WithHeader(this GraphQLHttpClient client, string name, string value)
+        {
+            client.HttpClient.DefaultRequestHeaders.Add(name, value);
+            return client;
+        }
+
+        /// <summary>
+        ///   Enables Automatic Persisted Queries, when <paramref name="when"/> resolve to <see langword="true" />.
+        /// </summary>
+        /// <param name="client"><see cref="GraphQLHttpClient"/>-instance to enable APQ for.</param>
+        /// <returns><paramref name="client"/> to allow for chaining calls.</returns>
+        public static GraphQLHttpClient WithAutomaticPersistedQueries(
+            this GraphQLHttpClient client,
+            Func<GraphQLRequest, bool>? when = null)
+        {
+            when ??= _ => true;
+
+            client.Options.EnableAutomaticPersistedQueries = when;
+            return client;
+        }
+    }
+}

--- a/src/Shared/src/GraphQL/GraphQLResponseExtensions.cs
+++ b/src/Shared/src/GraphQL/GraphQLResponseExtensions.cs
@@ -1,0 +1,21 @@
+using GraphQL;
+
+namespace Fetcharr.Shared.GraphQL
+{
+    public static class GraphQLResponseExtensions
+    {
+        /// <summary>
+        ///   If any errors are present on the response, throw an <see cref="AggregateException"/> with all errors.
+        /// </summary>
+        /// <param name="response"><see cref="GraphQLResponse{T}"/>-instance to check for errors on.</param>
+        public static void ThrowIfErrors<T>(this GraphQLResponse<T> response, string? message = null)
+        {
+            if(response.Errors is { Length: > 0 })
+            {
+                throw new AggregateException(
+                    message ?? "Error(s) received from GraphQL endpoint.",
+                    response.Errors.Select(error => new Exception(error.Message)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Overview

Allows Fetcharr to also fetch the watchlist of friends of the linked Plex account. By default, this is disabled, as it could lead to a lot of unwanted downloads.

If the PR fixes an issue, define it here:
- Fixes #12 

#### PR Checklist

- [x] Successful Docker build (`docker buildx build .`)