### PR TITLE
chore: lower log level to `Debug` for trivial operations

### DIFF
--- a/src/API/src/Services/RadarrMovieService.cs
+++ b/src/API/src/Services/RadarrMovieService.cs
@@ -34,7 +34,7 @@ namespace Fetcharr.API.Services
                     continue;
                 }
 
-                logger.LogInformation("Sending movie '{Title} ({Year})' to Radarr...", item.Title, item.Year);
+                logger.LogDebug("Sending movie '{Title} ({Year})' to Radarr...", item.Title, item.Year);
 
                 RadarrMovie? movie = await radarrClientCollection.GetMovieByTmdbAsync(item.TmdbId);
                 if(movie is null)

--- a/src/API/src/Services/SonarrSeriesService.cs
+++ b/src/API/src/Services/SonarrSeriesService.cs
@@ -34,7 +34,7 @@ namespace Fetcharr.API.Services
                     continue;
                 }
 
-                logger.LogInformation("Sending series '{Title} ({Year})' to Sonarr...", item.Title, item.Year);
+                logger.LogDebug("Sending series '{Title} ({Year})' to Sonarr...", item.Title, item.Year);
 
                 SonarrSeries? series = await sonarrClientCollection.GetSeriesByTvdbAsync(item.TvdbId);
                 if(series is null)

--- a/src/Cache/Core/src/Services/CacheEvictionService.cs
+++ b/src/Cache/Core/src/Services/CacheEvictionService.cs
@@ -42,7 +42,7 @@ namespace Fetcharr.Cache.Core.Services
                 return;
             }
 
-            logger.LogInformation("Evicting expired cache entries...");
+            logger.LogDebug("Evicting expired cache entries...");
 
             foreach(ICachingProvider provider in services.GetServices<ICachingProvider>())
             {

--- a/src/Provider.Radarr/src/RadarrClient.cs
+++ b/src/Provider.Radarr/src/RadarrClient.cs
@@ -185,7 +185,7 @@ namespace Fetcharr.Provider.Radarr
                     .Request($"/api/v3/movie/{movie.Id}")
                     .PutJsonAsync(requestBody);
 
-                logger.LogInformation(
+                logger.LogDebug(
                     "Updated '{Title} ({Year})' in Radarr instance '{Instance}'.",
                     movie.Title,
                     movie.Year,
@@ -198,7 +198,7 @@ namespace Fetcharr.Provider.Radarr
                 .Request("/api/v3/movie")
                 .PostJsonAsync(requestBody);
 
-            logger.LogInformation(
+            logger.LogDebug(
                 "Added '{Title} ({Year})' to Radarr instance '{Instance}'.",
                 movie.Title,
                 movie.Year,

--- a/src/Provider.Sonarr/src/SonarrClient.cs
+++ b/src/Provider.Sonarr/src/SonarrClient.cs
@@ -146,7 +146,7 @@ namespace Fetcharr.Provider.Sonarr
                     .Request($"/api/v3/series/{series.Id}")
                     .PutJsonAsync(requestBody);
 
-                logger.LogInformation(
+                logger.LogDebug(
                     "Updated '{Title} ({Year})' in Sonarr instance '{Instance}'.",
                     series.Title,
                     series.Year,
@@ -159,7 +159,7 @@ namespace Fetcharr.Provider.Sonarr
                 .Request("/api/v3/series")
                 .PostJsonAsync(requestBody);
 
-            logger.LogInformation(
+            logger.LogDebug(
                 "Added '{Title} ({Year})' to Sonarr instance '{Instance}'.",
                 series.Title,
                 series.Year,


### PR DESCRIPTION
#### Overview

Most of the logs from production builds aren't really necessary. If anything, they make it harder to spot errors.

This PR just changes most of the 'redundant' `LogInformation` calls to `LogDebug`.

#### PR Checklist

- [X] Successful Docker build (`docker buildx build .`)