### PR TITLE
fix: Check watchlist cache before returning

### DIFF
--- a/src/Provider.Plex/src/PlexWatchlistClient.cs
+++ b/src/Provider.Plex/src/PlexWatchlistClient.cs
@@ -48,7 +48,10 @@ namespace Fetcharr.Provider.Plex
                 CacheValue<IEnumerable<WatchlistMetadataItem>> cacheValue =
                     await cachingProvider.GetAsync<IEnumerable<WatchlistMetadataItem>>("watchlist");
 
-                return cacheValue.Value;
+                if(cacheValue.HasValue)
+                {
+                    return cacheValue.Value;
+                }
             }
 
             MediaResponse<WatchlistMetadataItem> watchlistContainer = await response


### PR DESCRIPTION
#### Overview

Hotfix for a common error, which arises after the watchlist cache has been evicted. If the watchlist hasn't changed, `FetchWatchlistAsync` would still return the value, even if it's evicted.

#### PR Checklist

- [X] Successful Docker build (`docker buildx build .`)