### PR TITLE
ci: fix `missing local config` for labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Labeler"
+name: "Label PR"
 
 on:
   - pull_request_target
@@ -10,4 +10,5 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/labeler@v5


### PR DESCRIPTION
#### Overview

The labeler has apparently not been labelling PRs, as it could never read the config file from the branch, as it's never cloned 🤷

#### PR Checklist

- [N/A] Successful Docker build (`docker buildx build .`)