### PR TITLE
fix: handle watchlist cache evictions

### DIFF
--- a/src/API/src/Program.cs
+++ b/src/API/src/Program.cs
@@ -43,7 +43,8 @@ namespace Fetcharr.API
 
             builder.Services.AddCaching(opts => opts
                 .UseHybrid("metadata", opts => opts.SQLite.DatabasePath = "metadata.sqlite")
-                .UseInMemory("watchlist"));
+                .UseInMemory("watchlist")
+                .UseInMemory("plex-graphql"));
 
             builder.Services.AddFetcharr();
             builder.Services.AddControllers();

--- a/src/Cache/InMemory/src/InMemoryCachingProvider.cs
+++ b/src/Cache/InMemory/src/InMemoryCachingProvider.cs
@@ -79,6 +79,8 @@ namespace Fetcharr.Cache.InMemory
             {
                 this._database[key] = new InMemoryCacheItem(value, _expiration);
 
+                Interlocked.Increment(ref this.CacheSize);
+
                 if(options.Value.SizeLimit > 0 && Interlocked.Read(ref this.CacheSize) >= options.Value.SizeLimit)
                 {
                     int itemsToRemove = (int) (Interlocked.Read(ref this.CacheSize) - options.Value.SizeLimit);


### PR DESCRIPTION
#### Overview

After the watchlist cache is evicted, we need to resend the request to Plex, as it otherwise wouldn't have sent any response body.

#### PR Checklist

- [X] Successful Docker build (`docker buildx build .`)