### PR TITLE
feat: allow skipping existing items

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -33,7 +33,11 @@
       "description": "Include a separate configuration file into the current one.",
       "additionalProperties": false,
       "anyOf": [
-        {"required": [ "config" ]}
+        {
+          "required": [
+            "config"
+          ]
+        }
       ],
       "properties": {
         "config": {
@@ -68,11 +72,17 @@
       "$ref": "#/$defs/service_filter_collection"
     },
     "root_folder": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Defines the path of the root folder to store items in. If not set, uses the first root folder from the instance."
     },
     "quality_profile": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Defines the name of the quality profile to add items as. If not set, uses the first quality profile from the instance."
     },
     "monitored": {
@@ -89,6 +99,11 @@
       "type": "boolean",
       "default": false,
       "description": "Whether to allow in-production series to be added to the instance.\nWhen in-production, genres and certifications are still not finalized; meaning filters likely won't work."
+    },
+    "update_existing": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether existing items in the service should be updated or left as-is."
     },
     "service_filter": {
       "type": "array",
@@ -133,19 +148,18 @@
       },
       "examples": [
         /* TV Parental Guidelines (US) */
-        "TV-Y",   // All children, including ages from 2-6
-        "TV-Y7",  // Directed at children age 7 and above.
-        "TV-G",   // General audience
-        "TV-PG",  // Parental guidance suggested
-        "TV-14",  // Parents strongly cautioned; may be unsuitable for children under the age of 14
-        "TV-MA",  // Mature audience only
-
+        "TV-Y", // All children, including ages from 2-6
+        "TV-Y7", // Directed at children age 7 and above.
+        "TV-G", // General audience
+        "TV-PG", // Parental guidance suggested
+        "TV-14", // Parents strongly cautioned; may be unsuitable for children under the age of 14
+        "TV-MA", // Mature audience only
         /* MPA film rating systems (US) */
-        "G",      // General audience; all ages admitted.
-        "PG",     // Parental guidance suggested; some material may not be suitable for children.
-        "PG-13",  // Parents strongly cautioned; some material may be inappropriate for children under 13.
-        "R",      // Restricted; under 17 requires accompanying parent or adult guardian.
-        "NC-17"   // Adults only; no one 17 and under admitted.
+        "G", // General audience; all ages admitted.
+        "PG", // Parental guidance suggested; some material may not be suitable for children.
+        "PG-13", // Parents strongly cautioned; some material may be inappropriate for children under 13.
+        "R", // Restricted; under 17 requires accompanying parent or adult guardian.
+        "NC-17" // Adults only; no one 17 and under admitted.
       ]
     },
     "service_filter_collection": {
@@ -164,7 +178,9 @@
     "plex": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["api_token"],
+      "required": [
+        "api_token"
+      ],
       "properties": {
         "api_token": {
           "type": "string",
@@ -212,7 +228,11 @@
           "$ref": "#/$defs/allow_in_production"
         },
         "series_type": {
-          "enum": ["Standard", "Daily", "Anime"],
+          "enum": [
+            "Standard",
+            "Daily",
+            "Anime"
+          ],
           "description": "Defines what type to assign to newly-added series."
         },
         "season_folder": {
@@ -226,14 +246,21 @@
           "description": "Defines whether to monitor new items, as they are released."
         },
         "monitored_items": {
-          "enum": ["None", "All", "FirstSeason", "OnlyShortSeries"],
+          "enum": [
+            "None",
+            "All",
+            "FirstSeason",
+            "OnlyShortSeries"
+          ],
           "default": "FirstSeason",
           "description": "Defines which seasons should be monitored for newly-added series."
         }
       },
       "if": {
         "properties": {
-          "monitored_items": { "const": "OnlyShortSeries" }
+          "monitored_items": {
+            "const": "OnlyShortSeries"
+          }
         }
       },
       "then": {
@@ -281,12 +308,21 @@
           "$ref": "#/$defs/allow_in_production"
         },
         "minimum_availability": {
-          "enum": ["TBA", "Announced", "InCinemas", "Released"],
+          "enum": [
+            "TBA",
+            "Announced",
+            "InCinemas",
+            "Released"
+          ],
           "default": "Released",
           "description": "Sets the minimum availability before the instance should attempt fetching the movie."
         },
         "monitored_items": {
-          "enum": ["None", "MovieOnly", "MovieAndCollection"],
+          "enum": [
+            "None",
+            "MovieOnly",
+            "MovieAndCollection"
+          ],
           "default": "MovieOnly",
           "description": "Defines which items should be monitored for newly-added movies."
         }

--- a/docs/docs/configuration/basic-setup.mdx
+++ b/docs/docs/configuration/basic-setup.mdx
@@ -154,6 +154,11 @@ Whether to force the instance to search for newly added content, right after it'
 Whether to allow in-production content, such as content which has only been announced.
 When content is in production, genres and certifications have often not been finalized, which will render instance filters useless.
 
+### `update_existing`
+**Optional.** Default: `true`
+
+Whether existing items in the service should be updated or left as-is. By default, if an item from a watchlist already exists on the service, it will be updated. This can become annoying if you frequently update monitoring, profile or other settings for an item in the service UI, as Fetcharr will override it on next sync. To opt out of this behaviour, set this value to `false`.
+
 ## Sonarr
 
 This section will only cover instance options that are unique to Sonarr. All the configuration options in [Services](#service) are still allowed.

--- a/fetcharr.example.yaml
+++ b/fetcharr.example.yaml
@@ -57,6 +57,11 @@ sonarr:
     ## Default: false
     # allow_in_production: true
 
+    ## Whether to update existing items in Sonarr or leave them as-is.
+    ## This can help prevent unwanted overwriting to series monitoring, quality profile, etc., which have been altered in Sonarr.
+    ## Default: true
+    # update_existing: false
+
     ## Sets the series type on newly-added items.
     ## Available values: [Standard, Daily, Anime]
     ## Default: Standard
@@ -136,6 +141,11 @@ radarr:
     ## When in-production, genres and certifications are still not finalized; meaning filters likely won't work.
     ## Default: false
     # allow_in_production: true
+
+    ## Whether to update existing items in Radarr or leave them as-is.
+    ## This can help prevent unwanted overwriting to movies monitoring, quality profile, etc., which have been altered in Radarr.
+    ## Default: true
+    # update_existing: false
 
     ## Sets the minimum availability before the instance should attempt fetching the movie.
     ## Available values: [TBA, Announced, InCinemas, Released]

--- a/src/Models/src/Configuration/FetcharrServiceConfiguration.cs
+++ b/src/Models/src/Configuration/FetcharrServiceConfiguration.cs
@@ -71,5 +71,11 @@ namespace Fetcharr.Models.Configuration
         /// </summary>
         [YamlMember(Alias = "allow_in_production")]
         public bool AllowInProduction { get; set; } = false;
+
+        /// <summary>
+        ///   Gets or sets whether existing items in the service should be updated or left as-is.
+        /// </summary>
+        [YamlMember(Alias = "update_existing")]
+        public bool UpdateExisting { get; set; } = true;
     }
 }

--- a/src/Provider.Radarr/src/RadarrClient.cs
+++ b/src/Provider.Radarr/src/RadarrClient.cs
@@ -179,7 +179,7 @@ namespace Fetcharr.Provider.Radarr
             };
 
             // If the movie already exists, just update it.
-            if(movie.Id is not null)
+            if(movie.Id is not null && configuration.UpdateExisting)
             {
                 IFlurlResponse newMovieResponse = await this._client
                     .Request($"/api/v3/movie/{movie.Id}")

--- a/src/Provider.Sonarr/src/SonarrClient.cs
+++ b/src/Provider.Sonarr/src/SonarrClient.cs
@@ -140,7 +140,7 @@ namespace Fetcharr.Provider.Sonarr
             };
 
             // If the series already exists, just update it.
-            if(series.Id is not null)
+            if(series.Id is not null && configuration.UpdateExisting)
             {
                 IFlurlResponse newSeriesResponse = await this._client
                     .Request($"/api/v3/series/{series.Id}")


### PR DESCRIPTION
#### Overview

Currently, if a property on an existing item is changed in the UI of a service (e.g. monitoring or profile is changed in Radarr/Sonarr), Fetcharr will override it on the next sync. This behavior can become annoying, so this PR allows the user to opt-out of updating existing series.

#### PR Checklist

- [X] Successful Docker build (`docker buildx build .`)